### PR TITLE
fix: correct install_requires version specifier for swanlab

### DIFF
--- a/UI-S1/setup.py
+++ b/UI-S1/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     "retry",
     "modelscope",
     "ninja",
-    "swanlab=0.6.3"
+    "swanlab==0.6.3"
 ]
 
 TEST_REQUIRES = ["pytest", "pre-commit", "py-spy"]


### PR DESCRIPTION
This PR fixes an invalid requirement specifier in UI-S1/setup.py where swanlab=0.6.3 was used.
According to PEP 440, version constraints must use ==, >=, <=, etc.
Replacing it with swanlab==0.6.3 allows pip install -e . to work without errors.