### PR TITLE
Add HarmonyOS NEXT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 # custom
 **/screenshot/*
 **/temp/*
+logs/*

--- a/Mobile-Agent-v3/README.md
+++ b/Mobile-Agent-v3/README.md
@@ -26,7 +26,7 @@
 GUI-Owl is a model series developed as part of the Mobile-Agent-v3 project. It achieves state-of-the-art performance across a range of GUI automation benchmarks, including ScreenSpot-v2, ScreenSpot-Pro, OSWorld-G, MMBench-GUI, Android Control, Android World, and OSWorld. Furthermore, it can be instantiated as various specialized agents within the Mobile-Agent-v3 multi-agent framework to accomplish more complex tasks.
 
 ## Deploy Mobile-Agent-v3 on your mobile device.
-❗At present, only **Android OS** and **Harmony OS** (version <= 4) support tool debugging. Other systems, such as **iOS**, do not support the use of Mobile-Agent for the time being.
+❗At present, only **Android OS** and **Harmony OS** support tool debugging. Other systems, such as **iOS**, do not support the use of Mobile-Agent for the time being.
 
 ### Install the dependencies required by the qwen model.
 ```
@@ -49,10 +49,23 @@ pip install numpy
 3. Switch the default input method in the system settings to "ADB Keyboard".
 
 ### Run
+#### Android
 ```
 cd Mobile-Agent-v3/mobile_v3
 python run_mobileagentv3.py \
     --adb_path "Your ADB path" \
+    --api_key "Your api key of vllm service" \
+    --base_url "Your base url of vllm service" \
+    --model "Your model name of vllm service" \
+    --instruction "The instruction you want Mobile-Agent-v3 to complete" \
+    --add_info "Some supplementary knowledge, can also be empty"
+```
+
+#### HarmonyOS
+```
+cd Mobile-Agent-v3/mobile_v3
+python run_mobileagentv3.py \
+    --hdc_path "Your HDC path" \
     --api_key "Your api key of vllm service" \
     --base_url "Your base url of vllm service" \
     --model "Your model name of vllm service" \

--- a/Mobile-Agent-v3/README_zh.md
+++ b/Mobile-Agent-v3/README_zh.md
@@ -26,7 +26,7 @@
 GUI-Owl是多智能体GUI自动化框架Mobile-Agent-v3的系列基础模型。其在众多GUI自动化评测榜单包括 ScreenSpot-v2, ScreenSpot-Pro, OSWorld-G, MMBench-GUI, Android Control, Android World, 和 OSWorld中取得SOTA性能。此外，其也可以扮演Mobile-Agent-v3中的各个智能体进行协同交互，以完成更为复杂的任务。
 
 ## 在你的手机上部署Mobile-Agent-v3
-❗目前仅安卓和鸿蒙系统（版本号 <= 4）支持工具调试。其他系统如iOS暂时不支持使用Mobile-Agent。
+❗目前仅安卓和鸿蒙系统支持工具调试。其他系统如iOS暂时不支持使用Mobile-Agent。
 
 
 ### 安装 qwen 模型所需的依赖项
@@ -50,10 +50,23 @@ pip install numpy
 3. 在系统设置中将默认输入法切换为 “ADB Keyboard”。
 
 ### 运行
+#### 安卓
 ```
 cd Mobile-Agent-v3/mobile_v3
 python run_mobileagentv3.py \
     --adb_path "Your ADB path" \
+    --api_key "Your api key of vllm service" \
+    --base_url "Your base url of vllm service" \
+    --model "Your model name of vllm service" \
+    --instruction "The instruction you want Mobile-Agent-v3 to complete" \
+    --add_info "Some supplementary knowledge, can also be empty"
+```
+
+#### 鸿蒙
+```
+cd Mobile-Agent-v3/mobile_v3
+python run_mobileagentv3.py \
+    --hdc_path "Your HDC path" \
     --api_key "Your api key of vllm service" \
     --base_url "Your base url of vllm service" \
     --model "Your model name of vllm service" \

--- a/Mobile-Agent-v3/mobile_v3/run_mobileagentv3.py
+++ b/Mobile-Agent-v3/mobile_v3/run_mobileagentv3.py
@@ -17,7 +17,16 @@ from utils.mobile_agent_e import (
 import utils.controller as controller
 from utils.call_mobile_agent_e import GUIOwlWrapper
 
-def run_instruction(adb_path, api_key, base_url, model, instruction, add_info, coor_type, if_notetaker, max_step=25, log_path="./logs"):
+def run_instruction(adb_path, hdc_path, api_key, base_url, model, instruction, add_info, coor_type, if_notetaker, max_step=25, log_path="./logs"):
+    if adb_path and hdc_path:
+        raise ValueError("adb_path and hdc_path cannot be provided at the same time. Please specify only one of them.")
+    if adb_path:
+        from utils.android_controller import AndroidController
+        controller = AndroidController(adb_path)
+    else:
+        from utils.harmonyos_controller import HarmonyOSController
+        controller = HarmonyOSController(hdc_path)
+
     if not os.path.exists(log_path):
         os.mkdir(log_path)
     
@@ -61,7 +70,7 @@ def run_instruction(adb_path, api_key, base_url, model, instruction, add_info, c
         
         # get the screenshot
         for _ in range(5):
-            if not controller.get_screenshot(adb_path, local_image_dir):
+            if not controller.get_screenshot(local_image_dir):
                 print("Get screenshot failed, retry.")
                 time.sleep(5)
             else:
@@ -186,16 +195,16 @@ def run_instruction(adb_path, api_key, base_url, model, instruction, add_info, c
                     action_object['coordinate2'] = [int(action_object['coordinate2'][0] / 1000 * width), int(action_object['coordinate2'][1] / 1000 * height)]
             
             if action_object['action'] == "click":
-                controller.tap(adb_path, action_object['coordinate'][0], action_object['coordinate'][1])
+                controller.tap(action_object['coordinate'][0], action_object['coordinate'][1])
             elif action_object['action'] == "swipe":
-                controller.slide(adb_path, action_object['coordinate'][0], action_object['coordinate'][1], action_object['coordinate2'][0], action_object['coordinate2'][1])
+                controller.slide(action_object['coordinate'][0], action_object['coordinate'][1], action_object['coordinate2'][0], action_object['coordinate2'][1])
             elif action_object['action'] == "type":
-                controller.type(adb_path, action_object['text'])
+                controller.type(action_object['text'])
             elif action_object['action'] == "system_button":
                 if action_object['button'] == "Back":
-                    controller.back(adb_path)
+                    controller.back()
                 elif action_object['button'] == "Home":
-                    controller.home(adb_path)
+                    controller.home()
             
         except:
             info_pool.last_action = {"action": "invalid"}
@@ -223,7 +232,7 @@ def run_instruction(adb_path, api_key, base_url, model, instruction, add_info, c
         
         # get the screenshot
         for _ in range(5):
-            if not controller.get_screenshot(adb_path, local_image_dir2):
+            if not controller.get_screenshot(local_image_dir2):
                 print("Get screenshot failed, retry.")
                 time.sleep(5)
             else:
@@ -294,6 +303,7 @@ if __name__ == '__main__':
         description="Run Mobile-Agent-v3 with a given model and instruction"
     )
     parser.add_argument("--adb_path", type=str)
+    parser.add_argument("--hdc_path", type=str)   
     parser.add_argument("--api_key", type=str)
     parser.add_argument("--base_url", type=str)
     parser.add_argument("--model", type=str)
@@ -303,5 +313,4 @@ if __name__ == '__main__':
     parser.add_argument("--notetaker", type=bool, default=False)
     args = parser.parse_args()
     
-    run_instruction(args.adb_path, args.api_key, args.base_url, args.model, args.instruction, args.add_info, args.coor_type, args.notetaker)
-    
+    run_instruction(args.adb_path, args.hdc_path, args.api_key, args.base_url, args.model, args.instruction, args.add_info, args.coor_type, args.notetaker)

--- a/Mobile-Agent-v3/mobile_v3/utils/android_controller.py
+++ b/Mobile-Agent-v3/mobile_v3/utils/android_controller.py
@@ -1,0 +1,58 @@
+import os
+import time
+import subprocess
+from .controller import Controller
+
+class AndroidController(Controller):
+    def __init__(self, adb_path):
+        self.adb_path = adb_path
+
+    def get_screenshot(self, save_path):
+        command = self.adb_path + " shell rm /sdcard/screenshot.png"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+        time.sleep(0.5)
+        command = self.adb_path + " shell screencap -p /sdcard/screenshot.png"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+        time.sleep(0.5)
+        command = self.adb_path + f" pull /sdcard/screenshot.png {save_path}"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+        
+        if not os.path.exists(save_path):
+            return False
+        else:
+            return True
+
+    def tap(self, x, y):
+        command = self.adb_path + f" shell input tap {x} {y}"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def type(self, text):
+        text = text.replace("\\n", "_").replace("\n", "_")
+        for char in text:
+            if char == ' ':
+                command = self.adb_path + f" shell input text %s"
+                subprocess.run(command, capture_output=True, text=True, shell=True)
+            elif char == '_':
+                command = self.adb_path + f" shell input keyevent 66"
+                subprocess.run(command, capture_output=True, text=True, shell=True)
+            elif 'a' <= char <= 'z' or 'A' <= char <= 'Z' or char.isdigit():
+                command = self.adb_path + f" shell input text {char}"
+                subprocess.run(command, capture_output=True, text=True, shell=True)
+            elif char in '-.,!?@\'°/:;()':
+                command = self.adb_path + f" shell input text \"{char}\""
+                subprocess.run(command, capture_output=True, text=True, shell=True)
+            else:
+                command = self.adb_path + f" shell am broadcast -a ADB_INPUT_TEXT --es msg \"{char}\""
+                subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def slide(self, x1, y1, x2, y2):
+        command = self.adb_path + f" shell input swipe {x1} {y1} {x2} {y2} 500"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def back(self):
+        command = self.adb_path + f" shell input keyevent 4"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def home(self):
+        command = self.adb_path + f" shell am start -a android.intent.action.MAIN -c android.intent.category.HOME"
+        subprocess.run(command, capture_output=True, text=True, shell=True)

--- a/Mobile-Agent-v3/mobile_v3/utils/controller.py
+++ b/Mobile-Agent-v3/mobile_v3/utils/controller.py
@@ -1,53 +1,26 @@
-import os
-import time
-import subprocess
+from abc import ABC, abstractmethod
 
-def get_screenshot(adb_path, save_path):
-    command = adb_path + " shell rm /sdcard/screenshot.png"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    time.sleep(0.5)
-    command = adb_path + " shell screencap -p /sdcard/screenshot.png"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    time.sleep(0.5)
-    command = adb_path + f" pull /sdcard/screenshot.png {save_path}"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    
-    if not os.path.exists(save_path):
-        return False
-    else:
-        return True
+class Controller(ABC):
+    @abstractmethod
+    def get_screenshot(self, save_path):
+        pass
 
-def tap(adb_path, x, y):
-    command = adb_path + f" shell input tap {x} {y}"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+    @abstractmethod
+    def tap(self, x, y):
+        pass
 
-def type(adb_path, text):
-    text = text.replace("\\n", "_").replace("\n", "_")
-    for char in text:
-        if char == ' ':
-            command = adb_path + f" shell input text %s"
-            subprocess.run(command, capture_output=True, text=True, shell=True)
-        elif char == '_':
-            command = adb_path + f" shell input keyevent 66"
-            subprocess.run(command, capture_output=True, text=True, shell=True)
-        elif 'a' <= char <= 'z' or 'A' <= char <= 'Z' or char.isdigit():
-            command = adb_path + f" shell input text {char}"
-            subprocess.run(command, capture_output=True, text=True, shell=True)
-        elif char in '-.,!?@\'°/:;()':
-            command = adb_path + f" shell input text \"{char}\""
-            subprocess.run(command, capture_output=True, text=True, shell=True)
-        else:
-            command = adb_path + f" shell am broadcast -a ADB_INPUT_TEXT --es msg \"{char}\""
-            subprocess.run(command, capture_output=True, text=True, shell=True)
+    @abstractmethod
+    def type(self, text):
+        pass
 
-def slide(adb_path, x1, y1, x2, y2):
-    command = adb_path + f" shell input swipe {x1} {y1} {x2} {y2} 500"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+    @abstractmethod
+    def slide(self, x1, y1, x2, y2):
+        pass
 
-def back(adb_path):
-    command = adb_path + f" shell input keyevent 4"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    
-def home(adb_path):
-    command = adb_path + f" shell am start -a android.intent.action.MAIN -c android.intent.category.HOME"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+    @abstractmethod
+    def back(self):
+        pass
+
+    @abstractmethod
+    def home(self):
+        pass

--- a/Mobile-Agent-v3/mobile_v3/utils/harmonyos_controller.py
+++ b/Mobile-Agent-v3/mobile_v3/utils/harmonyos_controller.py
@@ -1,40 +1,45 @@
 import os
 import time
 import subprocess
+from .controller import Controller
 
-def get_screenshot(hdc_path, save_path):
-    command = hdc_path + " shell rm /data/local/tmp/screenshot.png"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    time.sleep(0.5)
-    command = hdc_path + " shell uitest screenCap -p /data/local/tmp/screenshot.png"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    time.sleep(0.5)
-    command = hdc_path + " file recv /data/local/tmp/screenshot.png " + save_path
-    subprocess.run(command, capture_output=True, text=True, shell=True)
-    time.sleep(0.5)
-    
-    if not os.path.exists(save_path):
-        return False
-    else:
-        return True
+class HarmonyOSController(Controller):
+    def __init__(self, hdc_path):
+        self.hdc_path = hdc_path
 
-def tap(hdc_path, x, y):
-    command = hdc_path + f" hdc shell uitest uiInput click {x} {y}"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+    def get_screenshot(self, save_path):
+        command = self.hdc_path + " shell rm /data/local/tmp/screenshot.png"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+        time.sleep(0.5)
+        command = self.hdc_path + " shell uitest screenCap -p /data/local/tmp/screenshot.png"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+        time.sleep(0.5)
+        command = self.hdc_path + " file recv /data/local/tmp/screenshot.png " + save_path
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+        time.sleep(0.5)
 
-def type(hdc_path, text):
-    text = text.replace("\\n", "_").replace("\n", "_")
-    command = hdc_path + f" shell uitest uiInput inputText 1 1 {text}"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
- 
-def slide(hdc_path, x1, y1, x2, y2):
-    command = hdc_path + f" shell uitest uiInput swipe {x1} {y1} {x2} {y2} 500"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+        if not os.path.exists(save_path):
+            return False
+        else:
+            return True
 
-def back(hdc_path):
-    command = hdc_path + " shell uitest uiInput keyEvent Back"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+    def tap(self, x, y):
+        command = self.hdc_path + f" shell uitest uiInput click {x} {y}"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
 
-def home(hdc_path):
-    command = hdc_path + " shell uitest uiInput keyEvent Home"
-    subprocess.run(command, capture_output=True, text=True, shell=True)
+    def type(self, text):
+        text = text.replace("\\n", "_").replace("\n", "_")
+        command = self.hdc_path + f" shell uitest uiInput inputText 1 1 {text}"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def slide(self, x1, y1, x2, y2):
+        command = self.hdc_path + f" shell uitest uiInput swipe {x1} {y1} {x2} {y2} 500"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def back(self):
+        command = self.hdc_path + " shell uitest uiInput keyEvent Back"
+        subprocess.run(command, capture_output=True, text=True, shell=True)
+
+    def home(self):
+        command = self.hdc_path + " shell uitest uiInput keyEvent Home"
+        subprocess.run(command, capture_output=True, text=True, shell=True)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+import os
+
+os.system("python /home/cyg/fork/MobileAgent/Mobile-Agent-v3/mobile_v3/run_mobileagentv3.py --hdc_path hdc --api_key EMPTY --base_url http://localhost:8000/v1 --model models/GUI-Owl-32B --instruction '打开抖音应用，搜索石宇奇，播放第一个和石宇奇相关的视频。'")


### PR DESCRIPTION
新增对HarmonyOS NEXT系统的支持，添加harmonyos_controller.py文件，API接口保持和controller.py一致。用的时候args参数得加个hdc_path的支持。经过测试，在Mate60 HarmonyOS NEXT系统上能正常运行。