### PR TITLE
增加qwen3-vl的反归一化处理

### DIFF
--- a/PC-Agent/run.py
+++ b/PC-Agent/run.py
@@ -79,8 +79,8 @@ parser.add_argument('--instruction', type=str, default="")
 
 parser.add_argument('--use_som', type=int, default=1) # for action
 parser.add_argument('--draw_text_box', type=int, default=0, help="whether to draw text boxes in som.")
-# parser.add_argument('--font_path', type=str, default="/System/Library/Fonts/Supplemental/Times New Roman.ttf")
-parser.add_argument('--font_path', type=str, default=r"C:\Windows\Fonts\arial.ttf")
+parser.add_argument('--font_path', type=str, default="/System/Library/Fonts/Supplemental/Times New Roman.ttf")
+# parser.add_argument('--font_path', type=str, default=r"C:\Windows\Fonts\arial.ttf")
 parser.add_argument('--add_info', type=str, default="Click the search bar in the middle of the page to search")
 parser.add_argument('--disable_reflection', type=int, default=1)
 parser.add_argument('--clear_history_each_subtask', type=int, default=1)


### PR DESCRIPTION
在windows环境下使用qwen3-vl系列多模态时，因为Qwen3-VL模型返回的坐标将为相对坐标，坐标值会归一化到0-999，需要返归一化