### PR TITLE
Fix incorrect links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,8 +650,8 @@
                                 <h3>Mobile-Agent-E <small>(Preprint)</small></h3>
                                 <p><span data-lang="en">Self-evolving mobile assistant for complex tasks.</span><span data-lang="zh">可自我进化的移动助手，用于执行复杂任务。</span></p>
                                 <div class="timeline-links">
-                                    <a href="https://arxiv.org/abs/2502.14282" target="_blank">[Paper]</a>
-                                    <a href="https://github.com/X-PLUG/MobileAgent/tree/main/PC-Agent" target="_blank">[Code]</a>
+                                    <a href="https://arxiv.org/abs/2501.11733" target="_blank">[Paper]</a>
+                                    <a href="https://github.com/X-PLUG/MobileAgent/tree/main/Mobile-Agent-E" target="_blank">[Code]</a>
                                 </div>
                             </div>
                         </div>
@@ -674,8 +674,8 @@
                                 <h3>Mobile-Agent-v1 <small>(ICLR 2024 Workshop)</small></h3>
                                 <p><span data-lang="en">Autonomous multi-modal mobile device agent with visual perception.</span><span data-lang="zh">具有视觉感知的自主多模式移动设备代理。</span></p>
                                 <div class="timeline-links">
-                                    <a href="https://arxiv.org/abs/2406.01014" target="_blank">[Paper]</a>
-                                    <a href="https://github.com/X-PLUG/MobileAgent/tree/main/Mobile-Agent-v2" target="_blank">[Code]</a>
+                                    <a href="https://arxiv.org/abs/2401.16158" target="_blank">[Paper]</a>
+                                    <a href="https://github.com/X-PLUG/MobileAgent/tree/main/Mobile-Agent-v1" target="_blank">[Code]</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
In index.html, the paper and code links for Mobile Agent v1 and Mobile Agent E were incorrectly pointing to the Mobile Agent v2 or PC Agent URLs.

This PR fixes these links, so that each one points to the correct corresponding paper and code repository.