### PR TITLE
Replace spaces with underscores in save path(from user instruction)

### DIFF
--- a/Mobile-Agent-v3/mobile_v3/run_mobileagentv3.py
+++ b/Mobile-Agent-v3/mobile_v3/run_mobileagentv3.py
@@ -32,7 +32,7 @@ def run_instruction(adb_path, hdc_path, api_key, base_url, model, instruction, a
     
     now = datetime.now()
     time_str = now.strftime("%Y%m%d_%H%M%S")
-    save_path = f"{log_path}/{time_str}_{instruction[:10]}"
+    save_path = f"{log_path}/{time_str}_{instruction[:10].replace(' ', '_')}"
     os.mkdir(save_path)
     image_save_path = os.path.join(save_path, "images")
     os.mkdir(image_save_path)


### PR DESCRIPTION
When spaces in path, adb pull command executed in function get_screenshot() may be cut down.