### PR TITLE
fix: correct predict_mm call arguments and return handling

### DIFF
--- a/Mobile-Agent-v3.5/computer_use/run_gui_owl_1_5_for_pc.py
+++ b/Mobile-Agent-v3.5/computer_use/run_gui_owl_1_5_for_pc.py
@@ -238,7 +238,7 @@ def main():
 
         # ====== vllm ======
         vllm = GUIOwlWrapper(args.api_key, args.base_url, args.model)
-        output_text = vllm.predict_mm(messages)
+        output_text, _, _ = vllm.predict_mm(messages)
 
 
         # ======= dash =======

--- a/Mobile-Agent-v3.5/mobile_use/run_gui_owl_1_5_for_mobile.py
+++ b/Mobile-Agent-v3.5/mobile_use/run_gui_owl_1_5_for_mobile.py
@@ -185,7 +185,7 @@ def main():
         )
 
         vllm = GUIOwlWrapper(args.api_key, args.base_url, args.model)
-        output_text = vllm.predict_mm(messages)
+        output_text, _, _ = vllm.predict_mm(messages)
 
         print(f"[MODEL OUTPUT]\n{output_text}")
 


### PR DESCRIPTION
output_text = vllm.predict_mm(messages)这里返回的output_text 为tuple，导致在tool_call_block = output_text.split("<tool_call>\n")[1]使用时发生报错。