### PR TITLE
Add configurable OpenAI API URL for OpenAI-compatible providers

### DIFF
--- a/Mobile-Agent-E/README.md
+++ b/Mobile-Agent-E/README.md
@@ -91,6 +91,12 @@ Please refer to the `# Edit your Setting #` section in `inference_agent_E.py` fo
     export BACKBONE_TYPE="OpenAI"
     export OPENAI_API_KEY="your-openai-key"
     ```
+    If you want to use an OpenAI-compatible provider (for example Novita), set the OpenAI API URL as well:
+    ```
+    export BACKBONE_TYPE="OpenAI"
+    export OPENAI_API_URL="https://api.novita.ai/openai/v1/chat/completions"
+    export OPENAI_API_KEY="your-novita-key"
+    ```
     ```
     export BACKBONE_TYPE="Gemini"
     export GEMINI_API_KEY="your-gemini-key"

--- a/Mobile-Agent-E/README_zh.md
+++ b/Mobile-Agent-E/README_zh.md
@@ -91,6 +91,12 @@ pip install -r requirements.txt
     export BACKBONE_TYPE="OpenAI"
     export OPENAI_API_KEY="your-openai-key"
     ```
+    如果你想使用 OpenAI 兼容服务（例如 Novita），也可以额外指定 OpenAI API URL：
+    ```
+    export BACKBONE_TYPE="OpenAI"
+    export OPENAI_API_URL="https://api.novita.ai/openai/v1/chat/completions"
+    export OPENAI_API_KEY="your-novita-key"
+    ```
     ```
     export BACKBONE_TYPE="Gemini"
     export GEMINI_API_KEY="your-gemini-key"

--- a/Mobile-Agent-E/inference_agent_E.py
+++ b/Mobile-Agent-E/inference_agent_E.py
@@ -39,7 +39,7 @@ BACKBONE_TYPE = os.environ.get("BACKBONE_TYPE", default="OpenAI") # "OpenAI" or 
 assert BACKBONE_TYPE in ["OpenAI", "Gemini", "Claude"], "Unknown BACKBONE_TYPE"
 print("### Using BACKBONE_TYPE:", BACKBONE_TYPE)
 
-OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_API_URL = os.environ.get("OPENAI_API_URL", default="https://api.openai.com/v1/chat/completions")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", default=None)
 
 GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions" # OpenAI compatible


### PR DESCRIPTION
## Summary
- make `OPENAI_API_URL` configurable via environment variable in `Mobile-Agent-E/inference_agent_E.py`
- document how to use OpenAI-compatible endpoints such as Novita in `Mobile-Agent-E/README.md` and `README_zh.md`

## Example

```bash
export BACKBONE_TYPE="OpenAI"
export OPENAI_API_URL="https://api.novita.ai/openai/v1/chat/completions"
export OPENAI_API_KEY="your-novita-key"
```

## Validation
- `python3 -m py_compile Mobile-Agent-E/inference_agent_E.py`