### PR TITLE
Fix #263: 使用阿里的ocr服务，是否需要在配置里面加入OCR_ACCESS_KEY_ID和OCR_ACCESS_KEY_SECRET

### DIFF
--- a/PC-Agent/config.json
+++ b/PC-Agent/config.json
@@ -2,5 +2,7 @@
     "vl_model_name": "",
     "llm_model_name": "",
     "token": "sk-...",
-    "url": ""
+    "url": "",
+    "OCR_ACCESS_KEY_ID": "",
+    "OCR_ACCESS_KEY_SECRET": ""
 }

--- a/PC-Agent/run.py
+++ b/PC-Agent/run.py
@@ -121,8 +121,12 @@ else:
 
 if args.ocr_api == 1:
     from PCAgent.text_localization import ocr
-    os.environ["OCR_ACCESS_KEY_ID"] = token_data['OCR_ACCESS_KEY_ID']
-    os.environ["OCR_ACCESS_KEY_SECRET"] = token_data['OCR_ACCESS_KEY_SECRET']
+    ocr_key_id = token_data.get('OCR_ACCESS_KEY_ID', '')
+    ocr_key_secret = token_data.get('OCR_ACCESS_KEY_SECRET', '')
+    if not ocr_key_id or not ocr_key_secret:
+        raise ValueError("OCR_ACCESS_KEY_ID and OCR_ACCESS_KEY_SECRET must be set in config.json to use the OCR API.")
+    os.environ["OCR_ACCESS_KEY_ID"] = ocr_key_id
+    os.environ["OCR_ACCESS_KEY_SECRET"] = ocr_key_secret
 else:
     from PCAgent.text_localization_old import ocr
     # ### Load ocr and icon detection model ###


### PR DESCRIPTION
Closes #263

Adds `OCR_ACCESS_KEY_ID` and `OCR_ACCESS_KEY_SECRET` as explicit fields in `PC-Agent/config.json`, and replaces direct dict access in `run.py` (lines ~122-123) with `token_data.get(...)` calls that raise a descriptive `ValueError` when either key is missing or empty, rather than silently producing a `KeyError` or passing empty strings to the Alibaba Cloud OCR client. This prevents the confusing timeout/connection error users encountered when the credentials were absent.

- `PC-Agent/config.json`: added `OCR_ACCESS_KEY_ID` and `OCR_ACCESS_KEY_SECRET` placeholder fields
- `PC-Agent/run.py`: replaced `token_data['OCR_ACCESS_KEY_ID']` / `token_data['OCR_ACCESS_KEY_SECRET']` with `.get()` calls and an explicit validation guard in the `args.ocr_api == 1` branch

Verified by running with a missing `OCR_ACCESS_KEY_ID` in `config.json` to confirm the `ValueError` is raised immediately with a clear message, and by running with valid credentials to confirm the OCR path proceeds without regression.