### PR TITLE
Add MiniMax backbone support to Mobile-Agent-E

### DIFF
--- a/Mobile-Agent-E/MobileAgentE/api.py
+++ b/Mobile-Agent-E/MobileAgentE/api.py
@@ -35,6 +35,9 @@ def track_usage(res_json, api_key):
         elif "claude" in model:
             prompt_token_price = (3 / 1000000) * prompt_tokens
             completion_token_price = (15 / 1000000) * completion_tokens
+        elif "minimax-m3" in model.lower():
+            prompt_token_price = (0.6 / 1000000) * prompt_tokens
+            completion_token_price = (2.4 / 1000000) * completion_tokens
     return {
         # "api_key": api_key, # remove for better safety
         "id": res_json['id'] if "id" in res_json else None,

--- a/Mobile-Agent-E/README.md
+++ b/Mobile-Agent-E/README.md
@@ -86,7 +86,7 @@ Please refer to the `# Edit your Setting #` section in `inference_agent_E.py` fo
     ```
     export ADB_PATH="your/path/to/adb"
     ```
-2. Backbone model and API keys: you can choose from OpenAI, Gemini, and Claude; Set the corresponding keys as follows:
+2. Backbone model and API keys: you can choose from OpenAI, Gemini, Claude, and MiniMax; Set the corresponding keys as follows:
     ```
     export BACKBONE_TYPE="OpenAI"
     export OPENAI_API_KEY="your-openai-key"
@@ -98,6 +98,12 @@ Please refer to the `# Edit your Setting #` section in `inference_agent_E.py` fo
     ```
     export BACKBONE_TYPE="Claude"
     export CLAUDE_API_KEY="your-claude-key"
+    ```
+    ```
+    export BACKBONE_TYPE="MiniMax"
+    export MINIMAX_API_KEY="your-minimax-key"
+    # Optional: override the OpenAI-compatible endpoint
+    export MINIMAX_API_URL="https://api.minimax.io/v1/chat/completions"
     ```
 3. Perceptor: By default, the icon captioning model (`CAPTION_MODEL`) in Perceptor uses "qwen-vl-plus" from Qwen API:
     - Follow this to get an [Qwen API Key](https://help.aliyun.com/document_detail/2712195.html?spm=a2c4g.2712569.0.0.5d9e730aymB3jH) 

--- a/Mobile-Agent-E/README_zh.md
+++ b/Mobile-Agent-E/README_zh.md
@@ -86,7 +86,7 @@ pip install -r requirements.txt
     ```
     export ADB_PATH="your/path/to/adb"
     ```
-2. 基模型和 API keys: 您可以从 OpenAI、Gemini 或 Claude 中选择，设置相应的键如下:
+2. 基模型和 API keys: 您可以从 OpenAI、Gemini、Claude 或 MiniMax 中选择，设置相应的键如下:
     ```
     export BACKBONE_TYPE="OpenAI"
     export OPENAI_API_KEY="your-openai-key"
@@ -98,6 +98,12 @@ pip install -r requirements.txt
     ```
     export BACKBONE_TYPE="Claude"
     export CLAUDE_API_KEY="your-claude-key"
+    ```
+    ```
+    export BACKBONE_TYPE="MiniMax"
+    export MINIMAX_API_KEY="your-minimax-key"
+    # 可选：覆盖 OpenAI-compatible endpoint
+    export MINIMAX_API_URL="https://api.minimax.io/v1/chat/completions"
     ```
 3. 感知器: 默认情况下，Perceptor 中的图标字幕模型 (`CAPTION_MODEL`) 使用 Qwen API 中的“qwen-vl-plus”：
     - 按照此步骤获取 [Qwen API Key](https://help.aliyun.com/document_detail/2712195.html?spm=a2c4g.2712569.0.0.5d9e730aymB3jH)

--- a/Mobile-Agent-E/inference_agent_E.py
+++ b/Mobile-Agent-E/inference_agent_E.py
@@ -35,8 +35,8 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 ADB_PATH = os.environ.get("ADB_PATH", default="adb")
 
 ## Reasoning model configs
-BACKBONE_TYPE = os.environ.get("BACKBONE_TYPE", default="OpenAI") # "OpenAI" or "Gemini" or "Claude"
-assert BACKBONE_TYPE in ["OpenAI", "Gemini", "Claude"], "Unknown BACKBONE_TYPE"
+BACKBONE_TYPE = os.environ.get("BACKBONE_TYPE", default="OpenAI") # "OpenAI" or "Gemini" or "Claude" or "MiniMax"
+assert BACKBONE_TYPE in ["OpenAI", "Gemini", "Claude", "MiniMax"], "Unknown BACKBONE_TYPE"
 print("### Using BACKBONE_TYPE:", BACKBONE_TYPE)
 
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
@@ -48,6 +48,9 @@ GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", default=None)
 CLAUDE_API_URL = "https://api.anthropic.com/v1/messages"
 CLAUDE_API_KEY = os.environ.get("CLAUDE_API_KEY", default=None)
 
+MINIMAX_API_URL = os.environ.get("MINIMAX_API_URL", default="https://api.minimax.io/v1/chat/completions")
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", default=None)
+
 if BACKBONE_TYPE == "OpenAI":
     REASONING_MODEL = "gpt-4o-2024-11-20"
     KNOWLEDGE_REFLECTION_MODEL = "gpt-4o-2024-11-20"
@@ -57,6 +60,9 @@ elif BACKBONE_TYPE == "Gemini":
 elif BACKBONE_TYPE == "Claude":
     REASONING_MODEL = "claude-3-5-sonnet-20241022"
     KNOWLEDGE_REFLECTION_MODEL = "claude-3-5-sonnet-20241022"
+elif BACKBONE_TYPE == "MiniMax":
+    REASONING_MODEL = "MiniMax-M3"
+    KNOWLEDGE_REFLECTION_MODEL = "MiniMax-M3"
 
 ## you can specify a jsonl file path for tracking API usage
 USAGE_TRACKING_JSONL = None # e.g., usage_tracking.jsonl
@@ -385,6 +391,8 @@ def get_reasoning_model_api_response(chat, model_type=BACKBONE_TYPE, model=None,
         return inference_chat(chat, model, GEMINI_API_URL, GEMINI_API_KEY, usage_tracking_jsonl=USAGE_TRACKING_JSONL, temperature=temperature)
     elif model_type == "Claude":
         return inference_chat(chat, model, CLAUDE_API_URL, CLAUDE_API_KEY, usage_tracking_jsonl=USAGE_TRACKING_JSONL, temperature=temperature)
+    elif model_type == "MiniMax":
+        return inference_chat(chat, model, MINIMAX_API_URL, MINIMAX_API_KEY, usage_tracking_jsonl=USAGE_TRACKING_JSONL, temperature=temperature)
     else:
         raise ValueError(f"Unknown model type: {model_type}")
     


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax as a selectable Mobile-Agent-E backbone using the MiniMax-M3 model and OpenAI-compatible endpoint.
- Track MiniMax-M3 usage costs with the configured 0.6/2.4 USD per million token rates.
- Document MiniMax environment variables in English and Chinese READMEs.

## Test plan
- python3 -m py_compile Mobile-Agent-E/inference_agent_E.py Mobile-Agent-E/MobileAgentE/api.py
- git diff --check